### PR TITLE
Efficient rotations for NUTS

### DIFF
--- a/src/nh99/admodel.h
+++ b/src/nh99/admodel.h
@@ -1912,8 +1912,9 @@ public:
   void hybrid_mcmc_routine(int,int,double,int);
 
   // Functions added by Cole for HMC.
-  dvector rotate_space(const dvector& m, const dvector& x);
-  dvector rotate_space(const dmatrix& m, const dvector& x);
+  dvector rotate_pars(const dvector& m, const dvector& x);
+  dvector rotate_pars(const dmatrix& m, const dvector& x);
+  dvector rotate_gradient(const dvector& x, const dmatrix& m);
   int compute_next_window(int i, int anw, int warmup, int w1, int aws, int w3);
   bool slow_phase(int is, int warmup, int w1, int w3);
   std::string get_filename(const char* f);

--- a/src/nh99/admodel.h
+++ b/src/nh99/admodel.h
@@ -1828,7 +1828,7 @@ public:
   int repeatminflag;
   int mcmc2_flag;
   int robust_hybrid_flag;
-  int adapt_mass_flag;
+  int diagonal_metric_flag;
   long ifn;
   int maxfn;
   int iprint;

--- a/src/nh99/admodel.h
+++ b/src/nh99/admodel.h
@@ -1912,6 +1912,8 @@ public:
   void hybrid_mcmc_routine(int,int,double,int);
 
   // Functions added by Cole for HMC.
+  dvector rotate_space(const dvector& m, const dvector& x);
+  dvector rotate_space(const dmatrix& m, const dvector& x);
   int compute_next_window(int i, int anw, int warmup, int w1, int aws, int w3);
   bool slow_phase(int is, int warmup, int w1, int w3);
   std::string get_filename(const char* f);

--- a/src/nh99/admodel.h
+++ b/src/nh99/admodel.h
@@ -1828,6 +1828,7 @@ public:
   int repeatminflag;
   int mcmc2_flag;
   int robust_hybrid_flag;
+  int adapt_mass_flag;
   long ifn;
   int maxfn;
   int iprint;

--- a/src/nh99/hmc_functions.cpp
+++ b/src/nh99/hmc_functions.cpp
@@ -441,92 +441,90 @@ void function_minimizer::read_mle_hmc(int nvar, dvector& mle) {
 // often a vector or at least a lower triangular matrix. Thus we can make
 // it more efficient.
 dvector function_minimizer::rotate_pars(const dmatrix& m, const dvector& x)
-  {
-     if (x.indexmin() != m.colmin() || x.indexmax() != m.colmax())
-     {
-       cerr << " Incompatible array bounds in "
-       "dvector rotate_pars(const dmaxtrix& m, const dvector& x)\n";
-       ad_exit(21);
-     }
+{
+  if (x.indexmin() != m.colmin() || x.indexmax() != m.colmax())
+    {
+      cerr << " Incompatible array bounds in "
+	"dvector rotate_pars(const dmaxtrix& m, const dvector& x)\n";
+      ad_exit(21);
+    }
   
-     dvector tmp(m.rowmin(),m.rowmax());
-     int mmin=m.rowmin();
-     int mmax=m.rowmax();
-     int xmin=x.indexmin();
+  dvector tmp(m.rowmin(),m.rowmax());
+  int mmin=m.rowmin();
+  int mmax=m.rowmax();
+  int xmin=x.indexmin();
 
-     // If the metric is a dense matrix, chd will be lower diagonal so just
-     // loop over those. If doing adapt_mass then chd is still passed
-     // through as a matrix (poor programming) but only the digonal will be
-     // non-zero. Hence we can skip the off-diagonals and speed up the
-     // calculation.
-     if(diagonal_metric_flag==0){
-       for (int i=mmin; i<=mmax; i++)
-	 {
-	   tmp[i]=0;
-	   double * pm= (double *) &(m(i,xmin));
-	   double * px= (double *) &(x(xmin));
-	   double tt=0.0;
-	   for (int j=xmin; j<=i; j++)
-	     {
-	       tt+= *pm++ * *px++;
-	     }
-	   tmp[i]=tt;
-	 }
-     } else if(diagonal_metric_flag==1){
-       // Only the diagonals are nonzero so skip the offdiagonals completely
-       for (int i=mmin; i<=mmax; i++)
-	 {
-	   double * pm= (double *) &(m(i,i));
-	   double * px= (double *) &(x(i));
-	   tmp[i]= *pm * *px;
-	 }
-     } else {
-       cerr << "Invalid value for diagonal_metric_flag in rotate_pars" << endl;
-       ad_exit(21);
-     }
-     return(tmp);
+  // If the metric is a dense matrix, chd will be lower diagonal so just
+  // loop over those. If doing adapt_mass then chd is still passed
+  // through as a matrix (poor programming) but only the digonal will be
+  // non-zero. Hence we can skip the off-diagonals and speed up the
+  // calculation.
+  if(diagonal_metric_flag==0){
+    for (int i=mmin; i<=mmax; i++)
+      {
+	tmp[i]=0;
+	double * pm= (double *) &(m(i,xmin));
+	double * px= (double *) &(x(xmin));
+	double tt=0.0;
+	for (int j=xmin; j<=i; j++)
+	  {
+	    tt+= *pm++ * *px++;
+	  }
+	tmp[i]=tt;
+      }
+  } else if(diagonal_metric_flag==1){
+    // Only the diagonals are nonzero so skip the offdiagonals completely
+    for (int i=mmin; i<=mmax; i++)
+      {
+	double * pm= (double *) &(m(i,i));
+	double * px= (double *) &(x(i));
+	tmp[i]= *pm * *px;
+      }
+  } else {
+    cerr << "Invalid value for diagonal_metric_flag in rotate_pars" << endl;
+    ad_exit(21);
   }
+  return(tmp);
+}
 
 // See help for rotate_pars above, it's the same except rotating a gradient
 // vector rather than a par vector (although math is different)
 dvector function_minimizer::rotate_gradient(const dvector& x, const dmatrix& m)
-  {
-     if (x.indexmin() != m.colmin() || x.indexmax() != m.colmax())
-     {
-       cerr << " Incompatible array bounds in "
-       "dvector rotate_gradient(const dvector& x, const dmatrix& m)\n";
-       ad_exit(21);
-     }
+{
+  if (x.indexmin() != m.colmin() || x.indexmax() != m.colmax())
+    {
+      cerr << " Incompatible array bounds in "
+	"dvector rotate_gradient(const dvector& x, const dmatrix& m)\n";
+      ad_exit(21);
+    }
   
-     int mmin=m.colmin();
-     int mmax=m.colmax();
-     int ii=mmax-mmin+1;
-     dvector tmp(mmin,mmax);
-     if(diagonal_metric_flag==0){
-       for (int j = mmin; j <= mmax; ++j)
-	 {
-	   //	   int i = x.indexmin();
-	   dvector column = extract_column(m, j);
-	   double* pm = (double*)&column(j);
-	   double* px = (double*)&x(j);
-	   double sum = *px * *pm;
-	   for (int i=j; i <= mmax; ++i)
-	     {
-	       sum += *(++px) * *(++pm);
-	     }
-	   tmp[j] = sum;
-	 }
-     } else if(diagonal_metric_flag==1)
-       {
-	 for (int i=mmin; i<=mmax; i++)
-	   {
-	     double * pm= (double *) &(m(i,i));
-	     double * px= (double *) &(x(i));
-	     tmp[i] = *pm * *px;
-	   }
-       }else {
-       cerr << "Invalid value for diagonal_metric_flag in rotate_gradient" << endl;
-       ad_exit(21);
-     }
-     return(tmp);
+  int mmin=m.colmin();
+  int mmax=m.colmax();
+  dvector tmp(mmin,mmax);
+  if(diagonal_metric_flag==0){
+    for (int j = mmin; j <= mmax; ++j)
+      {
+	dvector column = extract_column(m, j);
+	double* pm = (double*)&column(j);
+	double* px = (double*)&x(j);
+	double sum = *px * *pm;
+	for (int i=j; i <= mmax; ++i)
+	  {
+	    sum += *(++px) * *(++pm);
+	  }
+	tmp[j] = sum;
+      }
+  } else if(diagonal_metric_flag==1)
+    {
+      for (int i=mmin; i<=mmax; i++)
+	{
+	  double * pm= (double *) &(m(i,i));
+	  double * px= (double *) &(x(i));
+	  tmp[i] = *pm * *px;
+	}
+    }else {
+    cerr << "Invalid value for diagonal_metric_flag in rotate_gradient" << endl;
+    ad_exit(21);
   }
+  return(tmp);
+}

--- a/src/nh99/hmc_functions.cpp
+++ b/src/nh99/hmc_functions.cpp
@@ -435,3 +435,51 @@ void function_minimizer::read_mle_hmc(int nvar, dvector& mle) {
     ad_exit(1);
   }
 }
+
+// Function written by Dave to help speed up some of the MCMC
+// calculations. The code has chd*x which rotates the space but this is
+// often a vector or at least a lower triangular matrix. Thus we can make
+// it more efficient
+dvector function_minimizer::rotate_space(const dmatrix& m, const dvector& x)
+  {
+     if (x.indexmin() != m.colmin() || x.indexmax() != m.colmax())
+     {
+       cerr << " Incompatible array bounds in "
+       "dvector rotate_space(const dmaxtrix& m, const dvector& x)\n";
+       ad_exit(21);
+     }
+  
+     dvector tmp(m.rowmin(),m.rowmax());
+     int mmin=m.rowmin();
+     int mmax=m.rowmax();
+     int xmin=x.indexmin();
+     int xmax=x.indexmax();
+  
+     for (int i=mmin; i<=mmax; i++)
+     {
+       tmp[i]=0;
+       double * pm= (double *) &(m(i,xmin));
+       double * px= (double *) &(x(xmin));
+       double tt=0.0;
+       for (int j=xmin; j<=i; j++)
+       {
+         tt+= *pm++ * *px++;
+       }
+       tmp[i]=tt;
+     }
+     return(tmp);
+  }
+
+dvector function_minimizer::rotate_space(const dvector& m, const dvector& x)
+  {
+     if (x.indexmin() != m.indexmin() || x.indexmax() != m.indexmax())
+     {
+       cerr << " Incompatible array bounds in "
+       "dvector  rotate_space(const dvector& m, const dvector& x)\n";
+       ad_exit(21);
+     }
+  
+     dvector tmp(x.indexmin(),x.indexmax());
+     tmp=x * m;
+     return(tmp);
+  }

--- a/src/nh99/hmc_functions.cpp
+++ b/src/nh99/hmc_functions.cpp
@@ -497,7 +497,6 @@ dvector function_minimizer::rotate_gradient(const dvector& x, const dmatrix& m)
 	"dvector rotate_gradient(const dvector& x, const dmatrix& m)\n";
       ad_exit(21);
     }
-  
   int mmin=m.colmin();
   int mmax=m.colmax();
   dvector tmp(mmin,mmax);

--- a/src/nh99/nuts.cpp
+++ b/src/nh99/nuts.cpp
@@ -298,7 +298,7 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
   dmatrix chdinv=inv(chd);
   // Can now inverse rotate y to be x (algorithm space)
   independent_variables x0(1,nvar);
-  x0=rotate_pars(chdinv,y0); // this is the initial value in algorithm space
+  x0=chdinv * y0; // this is the initial value in algorithm space
   // cout << "Starting from chd=" << chd << endl;
   ///
   // /// Old code to test that I know what's going on.
@@ -350,7 +350,7 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
       " hours or until " << nmcmc << " total iterations" << endl;
   }
   if(adapt_mass) cout << "Using diagonal mass matrix adaptation" << endl;
-  if(adapt_mass) adapt_mass_flag=1; else adapt_mass_flag=0;
+  if(adapt_mass) diagonal_metric_flag=1; else diagonal_metric_flag=0;
   cout << "Initial negative log density=" << nlltemp << endl;
   // write sampler parameters in format used by Shinystan
   dvector epsvec(1,nmcmc+1), epsbar(1,nmcmc+1), Hbar(1,nmcmc+1);
@@ -418,7 +418,7 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
     _thetaprime=theta; _thetaminus=theta; _thetaplus=theta;
     // Reset model parameters to theta, whether updated or not in previous
     // iteration.
-    z=rotate_pars(chd, theta);
+    z=chd*theta;
     nll=get_hybrid_monte_carlo_value(nvar,z,gr);
     gr2=rotate_gradient(gr, chd);
     H0=-nll-0.5*norm2(p); // initial Hamiltonian value

--- a/src/nh99/nuts.cpp
+++ b/src/nh99/nuts.cpp
@@ -350,6 +350,7 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
       " hours or until " << nmcmc << " total iterations" << endl;
   }
   if(adapt_mass) cout << "Using diagonal mass matrix adaptation" << endl;
+  if(adapt_mass) adapt_mass_flag=1; else adapt_mass_flag=0;
   cout << "Initial negative log density=" << nlltemp << endl;
   // write sampler parameters in format used by Shinystan
   dvector epsvec(1,nmcmc+1), epsbar(1,nmcmc+1), Hbar(1,nmcmc+1);

--- a/src/nh99/nuts.cpp
+++ b/src/nh99/nuts.cpp
@@ -363,6 +363,7 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
   //// ---------- Start of algorithm
   // Declare and initialize the variables needed for the algorithm
   independent_variables z(1,nvar);
+  independent_variables ztest(1,nvar);
   independent_variables ytemp(1,nvar);
   dvector gr(1,nvar);		// gradients in unbounded space
   dvector gr2(1,nvar);		// gradients in rotated space
@@ -418,6 +419,8 @@ void function_minimizer::nuts_mcmc_routine(int nmcmc,int iseed0,double dscale,
     // Reset model parameters to theta, whether updated or not in previous
     // iteration.
     z=chd*theta;
+    ztest=rotate_space(chd, theta);
+    if(is==1) cout << "chdtest=" << endl << z << endl << ztest << endl;
     nll=get_hybrid_monte_carlo_value(nvar,z,gr);
     gr2=gr*chd;
     H0=-nll-0.5*norm2(p); // initial Hamiltonian value


### PR DESCRIPTION
The mass matrix rotations (via the Cholesky decomposition) were slow, particularly for larger models. This pull request adds some new functions to do these rotations (parameter and gradient vectors) throughout. This is a very big improvement for when mass matrix adaptation is done, whereby the matrix is diagonal and the calculations can be  greatly simplified. 